### PR TITLE
Fix SSL booleans in influxdb client init

### DIFF
--- a/script/arris_stats.py
+++ b/script/arris_stats.py
@@ -177,8 +177,8 @@ def send_to_influx(stats, config):
         config['INFLUXDB']['username'],
         config['INFLUXDB']['password'],
         config['INFLUXDB']['database'],
-        config['INFLUXDB']['use_ssl'],
-        config['INFLUXDB']['verify_ssl']
+        config['INFLUXDB'].getboolean('use_ssl', fallback=False),
+        config['INFLUXDB'].getboolean('verify_ssl', fallback=True)
     )
 
     series = []


### PR DESCRIPTION
Thanks for putting this together, I'm looking forward to using it. I did find that whenever I tried using it against influxdb with SSL enabled it would ignore the SSL settings and try to use plain HTTP instead like so:
```
2020-05-17 19:49:49,045 INFO     Retreiving stats from http://192.168.100.1/cmconnectionstatus.html
2020-05-17 19:49:55,594 INFO     Parsing HTML for modem model sb8200
2020-05-17 19:49:55,667 INFO     Sending stats to InfluxDB (my.influx.server:8086)
2020-05-17 19:49:55,689 ERROR    400: Client sent an HTTP request to an HTTPS server.
2020-05-17 19:49:55,689 ERROR    Failed To Write To InfluxDB
```

These changes allowed me to use it to connect over SSL however if you'd like to merge them in.