### PR TITLE
Enable users to actually use config.ini

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,5 @@
 FROM python:3.8-alpine
 
-ENV arris_stats_debug=False \
-  destination=influxdb \
-  sleep_interval=300 \
-  modem_url=https://192.168.100.1/cmconnectionstatus.html \
-  modem_verify_ssl=False \
-  modem_auth_required=False \
-  modem_username=admin \
-  modem_password=None \
-  modem_model=sb8200 \
-  exit_on_auth_error=True \
-  exit_on_html_error=True \
-  clear_auth_token_on_html_error=True \
-  sleep_before_exit=True \
-  influx_host=localhost \
-  influx_database=cable_modem_stats \
-  influx_port=8086 \
-  influx_username=None \
-  influx_password=None \
-  influx_use_ssl=False \
-  influx_verify_ssl=True \
-  timestream_aws_access_key_id=None \
-  timestream_aws_secret_access_key=None \
-  timestream_database=cable_modem_stats \
-  timestream_table=cable_modem_stats \
-  timestream_aws_region=us-east-1
-
-
 ADD src/ /src
 WORKDIR /src
 

--- a/tests/test_arris_stats.py
+++ b/tests/test_arris_stats.py
@@ -70,42 +70,6 @@ class TestArrisStats(unittest.TestCase):
                 self.assertIsInstance(config[param], bool)
                 self.assertEqual(config[param], not default_config[param])
 
-    def test_dockerfile(self):
-        """ Ensure the docker file has the same hard coded ENV defaults """
-        default_config = arris_stats.get_default_config().copy()
-        path = 'Dockerfile'
-        with open(path, "r") as dockerfile:
-            dockerfile_contents = dockerfile.read().splitlines()
-
-        # We need to search each line until we find the ENV line, then find the end of the list of ENV variables
-        env_lines = []
-        first = None
-        for line in dockerfile_contents:
-
-            # Find the first line
-            if not first and re.match(r'^ENV \S+ \S+$', line):
-                # ENV arris_stats_debug=False \
-                first = line.split('ENV ')[1].split(' \\')[0].strip()
-                env_lines.append(first)
-            # Find the rest of the lines
-            elif first:
-                if re.match(r'\s*\S.+=\S.', line):
-                    env_lines.append(line.split(' \\')[0].strip())
-                # If the line isn't just whitespace or a comment, consider this the end of the ENV block
-                elif line.strip() == '' or re.match(r'^#', line.strip()):
-                    continue
-                else:
-                    break
-        # Now we have all the lines, test the values
-        for line in env_lines:
-            param = line.split('=')[0]
-            value = line.split('=')[1]
-            self.assertEqual(str(default_config[param]), value)  # Param is in Dockerfile but not default_config, or default values do not match
-            del default_config[param]  # Delete it once found so we can identify missing params
-
-        empty_dict = {}
-        self.assertEqual(default_config, empty_dict)  # default_config should be empty, if not then the Dockerfile is missing params
-
     def test_config_file(self):
         """ Ensure the config file as the same hard coded defaults as default_config """
 


### PR DESCRIPTION
The ENV settings in the Dockerfile override the config.ini file.  Combined with the unit test, this means that it is literally impossible to configure this software without generating diffs to the repository, which is an unfortunate antipattern.

Having environment variables override configuration options is a great way to enable admins to pass secrets into the container without putting them into their config.ini, but having the default Dockerfile override everything is a bit much.

It took me a surprising amount of time to figure out why my config options weren't being applied.  Removing the ENV settings enabled me to use config.ini to actually configure things, but resulted in a failing unit test.  This also removes the unit test that blindly asserts that those ENV files must exist.

Overall, this is a small change that should be a no-op to anyone running a configured stack, and will enable them to update their local repo without conflicts in Dockerfile.