### PR TITLE
Enable destination stdout for jq, etc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.8-alpine
 
-ENV arris_stats_debug=False \
+ENV log_level=info \
   destination=influxdb \
   sleep_interval=300 \
   modem_url=https://192.168.100.1/cmconnectionstatus.html \

--- a/README.md
+++ b/README.md
@@ -64,13 +64,18 @@ Run in a Docker container with the following (see other environment variables in
 ## Config Settings
 Config settings can be provided by the config.ini file, or set as ENV variables.  If you run arris_stats.py with --config config.ini, ENV settings will be ignored.
 
-- ```arris_stats_debug = False```
-    - enables debug logs
+- ```log_level = debug|info|warning|error```
+    - Valid options include:
+      - ```debug```
+      - ```info``` the default
+      - ```warning```
+      - ```error```
 - ```destination = influxdb```
     - Valid options include:
       - ```influxdb``` requires all influx_* params to be populated
       - ```timestream``` requires all timestream_* params to be populated
       - ```splunk``` requires all splunk_* params to be populated
+      - ```stdout_json``` will send the data to standard output in JSON format, great with ```log_level=error``` to suppress messages
 - ```sleep_interval = 300```
 - ```modem_url = https://192.168.100.1/cmconnectionstatus.html```
     - url for sb6183 = ```http://192.168.100.1/RgConnect.asp```

--- a/src/arris_stats.py
+++ b/src/arris_stats.py
@@ -39,8 +39,7 @@ def main():
     config_path = args.config
     config = get_config(config_path)
 
-    init_logger(args.debug or config.get('arris_stats_debug'),
-                args.info or config.get('arris_stats_info'))
+    init_logger(args.log_level or config.get('log_level'))
 
     sleep_interval = int(config['sleep_interval'])
     destination = config['destination']
@@ -115,9 +114,11 @@ def get_args():
     """ Get argparser args """
     parser = argparse.ArgumentParser()
     parser.add_argument('--config', metavar='config_file_path', help='Path to config file', required=False)
-    parser.add_argument('--debug', help='Enable debug logging', action='store_true', required=False, default=False)
-    parser.add_argument('--info', help='Enable info logging', action='store_true', required=False, default=False)
+    parser.add_argument('--debug', help='Set log_level to DEBUG', action='store_true', required=False, default=False)
+    parser.add_argument('--log-level', help='Set log_level', action='store', type=str.lower, required=False, choices=["debug", "info", "warning", "error"])
     args = parser.parse_args()
+    if args.debug:
+        args.log_level = "debug"
     return args
 
 
@@ -125,6 +126,7 @@ def get_default_config():
     return {
 
         # Main
+        'log_level': "info",
         'arris_stats_debug': False,
         'destination': 'influxdb',
         'sleep_interval': 300,
@@ -342,17 +344,21 @@ def str_to_bool(string, name):
     raise ValueError('Config parameter % s should be boolean "true" or "false", but value is neither of those.' % name)
 
 
-def init_logger(debug=False, info=False):
+def init_logger(log_level="info"):
     """ Start the python logger """
     log_format = '%(asctime)s %(levelname)-8s %(message)s'
 
-    level = logging.ERROR
+    level = logging.INFO
 
-    if info:
-        level = logging.INFO
-    
-    if debug:
+    if log_level == "debug":
         level = logging.DEBUG
+    elif log_level == "info":
+        level = logging.INFO
+    elif log_level == "warning":
+        level = logging.WARNING
+    elif log_level == "error":
+        level = logging.ERROR
+    
 
     # https://stackoverflow.com/a/61516733/866057
     try:

--- a/src/arris_stats.py
+++ b/src/arris_stats.py
@@ -104,7 +104,7 @@ def main():
         elif destination == 'splunk':
             import arris_stats_splunk  # pylint: disable=import-outside-toplevel
             arris_stats_splunk.send_to_splunk(stats, config)
-        elif destination == 'stdout':
+        elif destination == 'stdout_json':
             print(json.dumps(stats))
         else:
             error_exit('Destination %s not supported!  Aborting.' % destination, sleep=False)
@@ -114,7 +114,6 @@ def get_args():
     """ Get argparser args """
     parser = argparse.ArgumentParser()
     parser.add_argument('--config', metavar='config_file_path', help='Path to config file', required=False)
-    parser.add_argument('--debug', help='Set log_level to DEBUG', action='store_true', required=False, default=False)
     parser.add_argument('--log-level', help='Set log_level', action='store', type=str.lower, required=False, choices=["debug", "info", "warning", "error"])
     args = parser.parse_args()
     if args.debug:
@@ -127,7 +126,6 @@ def get_default_config():
 
         # Main
         'log_level': "info",
-        'arris_stats_debug': False,
         'destination': 'influxdb',
         'sleep_interval': 300,
         'modem_url': 'https://192.168.100.1/cmconnectionstatus.html',

--- a/src/config.ini.example
+++ b/src/config.ini.example
@@ -1,4 +1,3 @@
-arris_stats_debug = False
 log_level = info
 destination = influxdb
 sleep_interval = 300

--- a/src/config.ini.example
+++ b/src/config.ini.example
@@ -1,5 +1,5 @@
 arris_stats_debug = False
-arris_stats_info = True
+log_level = info
 destination = influxdb
 sleep_interval = 300
 modem_url = https://192.168.100.1/cmconnectionstatus.html

--- a/src/config.ini.example
+++ b/src/config.ini.example
@@ -1,4 +1,5 @@
 arris_stats_debug = False
+arris_stats_info = True
 destination = influxdb
 sleep_interval = 300
 modem_url = https://192.168.100.1/cmconnectionstatus.html


### PR DESCRIPTION
* Enable `destination = stdout` in the config file, to allow json data to be sent to standard out

* Enable `arris_stats_info = True` in the config file, to allow information messages to be enabled or disabled

This could be implemented as a log_level (DEBUG/INFO/ERROR) instead of True/False.