### PR TITLE
fix upstream table header skip test for sb8200

### DIFF
--- a/src/arris_stats_sb8200.py
+++ b/src/arris_stats_sb8200.py
@@ -58,11 +58,12 @@ def parse_html_sb8200(html):
         if table_row.th:
             continue
 
+        channel_id = table_row.find_all('td')[1].text.strip()
+
         # Some firmwares have a header row not already skiped by "if table_row.th", skip it if channel_id isn't an integer
         if not channel_id.isdigit():
             continue
 
-        channel_id = table_row.find_all('td')[1].text.strip()
         frequency = table_row.find_all('td')[4].text.replace(" Hz", "").strip()
         power = table_row.find_all('td')[6].text.replace(" dBmV", "").strip()
 


### PR DESCRIPTION
The upstream table parsing in `arris_stats_sb8200.py` includes a check for skipping over the header row but it comes before setting `channel_id` from the row being tested, so it actually checks the last downstream row instead.

I swapped the lines around to match the downstream header check to resolve